### PR TITLE
Fix: don't try to iterate on something that is not defined

### DIFF
--- a/src/get-pages.ts
+++ b/src/get-pages.ts
@@ -45,8 +45,10 @@ const fetchPath = async (spaceName: string, spaceId: string, path: string, node:
     await fetchPage(spaceId, spaceName, absNodePath);
   }
 
-  for (const page of node.pages) {
-    fetchPath(spaceName, spaceId, absNodePath, page);
+  if (node.pages !== undefined) {
+    for (const page of node.pages) {
+      fetchPath(spaceName, spaceId, absNodePath, page);
+    }
   }
 };
 


### PR DESCRIPTION
Within my gitbook space (in an organization) the API response seems to
contain nodes with `pages` that is undefined. This lead to a crash in
the `get-pages` command.

With the following patch I could retrieve all the pages of my space
without any issues.