### PR TITLE
Adding/extending support for several unhandled block types (GitBook Page refs,Hint,Anchor,inline-image,etc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 built/
 data/
+.env
+

--- a/README.md
+++ b/README.md
@@ -3,18 +3,20 @@
 ## Getting started
 
 ```bash
+# - ! This must be re-run if you make any changes to the scripts (get-content.ts, parse-pages.ts, etc)
 npm run build
 
 # Fetch and parse an entire space
-# -- ℹ️ If your spaces are under the user's "Personal" rather than in an organization, use "personal" as the organization id.
+# - ℹ️ If your spaces are under the user's "Personal" rather than in an organization, use "personal" as the organization id.
 API_TOKEN=xxxx npm run get-content -- [organization id | "personal"]
 API_TOKEN=xxxx npm run get-pages -- [space name]
 npm run parse-pages -- [space name]
 
-# See documents in data/
+# See documents in data/*
 
+# OR
 # Parse a single page
-npm run gitbook-to-md -- [page.json]
+npm run gitbook-to-md -- [Space Name] [data/space-name/subfolder/page.json]
 ```
 
 ## GitBook Hints
@@ -23,17 +25,17 @@ npm run gitbook-to-md -- [page.json]
 
 > ⏹️ An informational hint
 
-
-
 ## Images in GitBook
 
 If the image information is available in the GitBook Spaces API response (under `files`), it will be fetched based on the ID and the GitBook download URL will be part of the rendered output.
 
 _Why not just set the download URL as the image link?_
 
-We don't want users migrating away from the service to get a false sense of security and forget to find a new host for their images. It would be very easy to let the GitBook CDN "just work" for a bit, serving the images happily and making the migration look successful - up until the day it doesn't 💥.
+We don't want users migrating away from GitBook to get a false sense of security and forget to find a new host for their images. It would be very easy to let the GitBook CDN _"just work"_ for a while, serving the images happily and making the migration look finished -- until the day it doesn't because GB deleted them💥.
 
 ## Contributions
+
+When developing changes to the scripts, be sure to run `npm run build` before QA testing, to ensure you have the latest version.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ npm run gitbook-to-md -- [page.json]
 
 ## GitBook Hints
 
-Hints _(aka 'call-outs' or 'admonitions')_ are not natively supported in Markdown. For now, they are rendered as a block quote.
+[GitBook Hints](https://docs.gitbook.com/content-creation/blocks/hint) _(aka ['call-outs'](https://docs.readme.com/rdmd/docs/callouts) or ['admonitions'](https://squidfunk.github.io/mkdocs-material/reference/admonitions/))_ are not natively supported in Markdown. For now, they are rendered as a block quote with an emoji, e.g.:
+
+> ⏹️ An informational hint
+
+
 
 ## Images in GitBook
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ Hints _(aka 'call-outs' or 'admonitions')_ are not natively supported in Markdow
 
 ## Images in GitBook
 
-⚠️ Work in Progress - for now, images end up as either a simple ref (`files/-Mered4r4t0g.png`) or `undefined`. There is enough information returned from GitBook API we can update to the actual CDN download links, to make it easy for users to get the images back.
+If the image information is available in the GitBook Spaces API response (under `files`), it will be fetched based on the ID and the GitBook download URL will be part of the rendered output.
+
+_Why not just set the download URL as the image link?_
+
+We don't want users migrating away from the service to get a false sense of security and forget to find a new host for their images. It would be very easy to let the GitBook CDN "just work" for a bit, serving the images happily and making the migration look successful - up until the day it doesn't 💥.
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,17 @@ npm run parse-pages -- [space name]
 npm run gitbook-to-md -- [page.json]
 ```
 
-## Testing
+## GitBook Hints
+
+Hints _(aka 'call-outs' or 'admonitions')_ are not natively supported in Markdown. For now, they are rendered as a block quote.
+
+## Images in GitBook
+
+⚠️ Work in Progress - for now, images end up as either a simple ref (`files/-Mered4r4t0g.png`) or `undefined`. There is enough information returned from GitBook API we can update to the actual CDN download links, to make it easy for users to get the images back.
+
+## Contributions
+
+### Testing
 
 ```bash
 # Run tests

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 npm run build
 
 # Fetch and parse an entire space
-API_TOKEN=xxxx npm run get-content -- [organisation id]
+# -- ℹ️ If your spaces are under the user's "Personal" rather than in an organization, use "personal" as the organization id.
+API_TOKEN=xxxx npm run get-content -- [organization id | "personal"]
 API_TOKEN=xxxx npm run get-pages -- [space name]
 npm run parse-pages -- [space name]
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "types": "tsc --noEmit --incremental false",
+    "format-check": "prettier --check src/",
+    "format": "prettier --write src/",
     "build": "babel src --out-dir built --extensions \".ts,.js\"",
     "get-content": "node built/get-content.js",
     "get-pages": "node built/get-pages.js",

--- a/src/MarkdownRenderer.test.ts
+++ b/src/MarkdownRenderer.test.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "fs";
 import MarkdownRenderer from "./MarkdownRenderer";
-import type { BlockNode, InlineNode, LinkNode, gitbookLinkNode, ImageNode, EmojiNode, LeafNode, Files, SpaceContent, SpaceContentFile, SpaceContentPage } from "./MarkdownRenderer";
+import type { BlockNode, InlineNode, LinkNode, gitbookLinkNode, ImageLinkNode, EmojiNode, LeafNode, Files, SpaceContent, SpaceContentFile, SpaceContentPage, ImageFileNode } from "./MarkdownRenderer";
 
 const defaultSpaceContentTestInitializer: SpaceContent = {
     object: "revision",
@@ -380,8 +380,8 @@ describe("renderInline()", () => {
     );
   });
 
-  it("renders images", () => {
-    const node: ImageNode = {
+  it("renders inline link images", () => {
+    const node: ImageLinkNode = {
       object: "inline",
       type: "inline-image",
       data: { caption: "my image", ref: { url: "https://example.com" }, size: "line" },
@@ -392,6 +392,77 @@ describe("renderInline()", () => {
     const renderer = new MarkdownRenderer(FilesInitializer, defaultSpaceContentTestInitializer);
     expect(renderer.renderInline(node, 0)).toEqual(
       "![my image](https://example.com)"
+    );
+  });
+
+  it("renders inline file imagess with no info in Space", () => {
+    const node: ImageFileNode = {
+      object: "inline",
+      type: "inline-image",
+      data: {
+        "ref": {
+            "kind": "file",
+            "file": "-M9ar8a0oxijwIvaQYA4"
+        },
+        "size": "original"
+    },
+      nodes: [
+        {
+            "object": "text",
+            "leaves": [
+                {
+                    "object": "leaf",
+                    "text": "",
+                    "marks": [],
+                    "selections": []
+                }
+            ]
+        }
+    ]
+    };
+    const renderer = new MarkdownRenderer(FilesInitializer, defaultSpaceContentTestInitializer);
+    expect(renderer.renderInline(node, 0)).toEqual(
+      "![unknown-image-file.-M9ar8a0oxijwIvaQYA4]()"
+    );
+  });
+
+  it("renders inline file images with info in Space", () => {
+    const spaceContent: SpaceContent = JSON.parse(JSON.stringify(defaultSpaceContentTestInitializer))
+    spaceContent.files = [
+      {
+        "id": "-MC0GpDJ0v0g6fZ7qshj",
+        "name": "image.png",
+        "downloadURL": "https://files.gitbook.com/v0/b/gitbook-legacy-files/o/assets%2F-M8N-2NuR5V0ryoqtTWk%2F-MC0GoHeyr3P9glwOxk7%2F-MC0GpDJ0v0g6fZ7qshj%2Fimage.png?alt=media&token=5246ece1-816a-4432-b066-0f6709b06b4f",
+        "contentType": "image/png"
+    },
+    ]
+    const node: ImageFileNode = {
+      object: "inline",
+      type: "inline-image",
+      data: {
+        "ref": {
+            "kind": "file",
+            "file": "-MC0GpDJ0v0g6fZ7qshj"
+        },
+        "size": "original"
+    },
+      nodes: [
+        {
+            "object": "text",
+            "leaves": [
+                {
+                    "object": "leaf",
+                    "text": "",
+                    "marks": [],
+                    "selections": []
+                }
+            ]
+        }
+    ]
+    };
+    const renderer = new MarkdownRenderer(FilesInitializer, spaceContent);
+    expect(renderer.renderInline(node, 0)).toEqual(
+      "![download: https://files.gitbook.com/v0/b/gitbook-legacy-files/o/assets%2F-M8N-2NuR5V0ryoqtTWk%2F-MC0GoHeyr3P9glwOxk7%2F-MC0GpDJ0v0g6fZ7qshj%2Fimage.png?alt=media&token=5246ece1-816a-4432-b066-0f6709b06b4f](image.png \"-MC0GpDJ0v0g6fZ7qshj\")"
     );
   });
 

--- a/src/MarkdownRenderer.test.ts
+++ b/src/MarkdownRenderer.test.ts
@@ -439,6 +439,18 @@ describe("renderInline()", () => {
     expect(renderer.renderInline(node, 0)).toEqual(
       `[**installing**](/getting-started/install "Install Title")`
     );
+
+    // also anchor type
+    node.data = {
+      ref: {
+          kind: "anchor",
+          anchor: "list-of-ids",
+          page: "-M9UwQjn8e1kKADwPrrF"
+      }
+  }
+    expect(renderer.renderInline(node, 0)).toEqual(
+      `[**installing**](/getting-started/install#list-of-ids "Install Title")`
+    );
   });
 
   it("renders inline link images", () => {

--- a/src/MarkdownRenderer.test.ts
+++ b/src/MarkdownRenderer.test.ts
@@ -277,7 +277,7 @@ describe("renderBlock()", () => {
     // it renders with 2 extra newlines which end up harmless, not worth diggin for now. Hack in place in renderBlock()
     // - Culprit is at the `(node.type == "paragraph") {` section adding extra \n's.
     expect(renderer.renderBlock(node, 0)).toEqual(
-      "> An important hint callout block for user information. Continued text.\n> With a newline.\n\n"
+      "> ⏹ An important hint callout block for user information. Continued text.\n> With a newline.\n\n"
     );
   });
 
@@ -443,11 +443,11 @@ describe("renderInline()", () => {
     // also anchor type
     node.data = {
       ref: {
-          kind: "anchor",
-          anchor: "list-of-ids",
-          page: "-M9UwQjn8e1kKADwPrrF"
-      }
-  }
+        kind: "anchor",
+        anchor: "list-of-ids",
+        page: "-M9UwQjn8e1kKADwPrrF",
+      },
+    };
     expect(renderer.renderInline(node, 0)).toEqual(
       `[**installing**](/getting-started/install#list-of-ids "Install Title")`
     );

--- a/src/MarkdownRenderer.test.ts
+++ b/src/MarkdownRenderer.test.ts
@@ -200,6 +200,37 @@ describe("renderBlock()", () => {
     expect(renderer.renderBlock(node, 0)).toEqual("> line one\n> line two\n");
   });
 
+  it("renders a hint", () => {
+    const node: BlockNode = {
+      object: "block",
+      type: "hint",
+      data: {
+        style: "info"
+      },
+      nodes: [
+        {
+          object: "block",
+          type: "paragraph",
+          data: {},
+          nodes: [
+            {
+              object: "text",
+              leaves: [{ object: "leaf", text: "An important hint callout block for user information.", marks: [], selections: [] }],
+            },
+            {
+              object: "text",
+              leaves: [{ object: "leaf", text: " Continued text.\nWith a newline.", marks: [], selections: [] }],
+            }
+          ]
+        },
+      ],
+    };
+
+    // it renders with 2 extra newlines which end up harmless, not worth diggin for now. Hack in place in renderBlock()
+    // - Culprit is at the `(node.type == "paragraph") {` section adding extra \n's.
+    expect(renderer.renderBlock(node, 0)).toEqual("> An important hint callout block for user information. Continued text.\n> With a newline.\n\n");
+  });
+
   it("renders a code block", () => {
     const node: BlockNode = {
       object: "block",

--- a/src/MarkdownRenderer.test.ts
+++ b/src/MarkdownRenderer.test.ts
@@ -313,6 +313,12 @@ describe("renderBlock()", () => {
     expect(renderer.renderBlock(node, 0)).toEqual(
       "```javascript\n// line one\n// line two\n```\n\n"
     );
+
+    // also handle if they don't have syntax defined
+    node.data = {};
+    expect(renderer.renderBlock(node, 0)).toEqual(
+      "```\n// line one\n// line two\n```\n\n"
+    );
   });
 
   it("renders a paragraph", () => {

--- a/src/MarkdownRenderer.test.ts
+++ b/src/MarkdownRenderer.test.ts
@@ -1,17 +1,28 @@
 import { promises as fs } from "fs";
 import MarkdownRenderer from "./MarkdownRenderer";
-import type { BlockNode, InlineNode, LinkNode, gitbookLinkNode, ImageLinkNode, EmojiNode, LeafNode, Files, SpaceContent, SpaceContentFile, SpaceContentPage, ImageFileNode } from "./MarkdownRenderer";
+import type {
+  BlockNode,
+  InlineNode,
+  LinkNode,
+  gitbookLinkNode,
+  ImageLinkNode,
+  EmojiNode,
+  LeafNode,
+  Files,
+  SpaceContent,
+  SpaceContentFile,
+  SpaceContentPage,
+  ImageFileNode,
+} from "./MarkdownRenderer";
 
 const defaultSpaceContentTestInitializer: SpaceContent = {
-    object: "revision",
-    id: "-MVYmSNifA9RV4lb6xiN",
-    "parents": [
-        "-MOnQAmPI8w7ceDocqT1"
-    ],
-    pages: [],
-    files: []
-}
-const FilesInitializer: Files = {}
+  object: "revision",
+  id: "-MVYmSNifA9RV4lb6xiN",
+  parents: ["-MOnQAmPI8w7ceDocqT1"],
+  pages: [],
+  files: [],
+};
+const FilesInitializer: Files = {};
 
 describe("render", () => {
   it("renders a sample document", async () => {
@@ -25,14 +36,20 @@ describe("render", () => {
     );
     const doc = JSON.parse(json).document;
 
-    const renderer = new MarkdownRenderer(FilesInitializer, defaultSpaceContentTestInitializer);
+    const renderer = new MarkdownRenderer(
+      FilesInitializer,
+      defaultSpaceContentTestInitializer
+    );
     const output: string = renderer.render(doc);
 
     expect(output).toEqual(expectedMd);
   });
 
   it("renders nested list items", async () => {
-    const renderer = new MarkdownRenderer(FilesInitializer, defaultSpaceContentTestInitializer);
+    const renderer = new MarkdownRenderer(
+      FilesInitializer,
+      defaultSpaceContentTestInitializer
+    );
     const json = await fs.readFile("fixtures/nested-list.json", "utf8");
     const node = JSON.parse(json).document;
     const result: string = renderer.render(node);
@@ -41,17 +58,28 @@ describe("render", () => {
   });
 
   it("renders mixed type nested list items", async () => {
-    const renderer = new MarkdownRenderer(FilesInitializer, defaultSpaceContentTestInitializer);
-    const json = await fs.readFile("fixtures/mixed-order-nested-list.json", "utf8");
+    const renderer = new MarkdownRenderer(
+      FilesInitializer,
+      defaultSpaceContentTestInitializer
+    );
+    const json = await fs.readFile(
+      "fixtures/mixed-order-nested-list.json",
+      "utf8"
+    );
     const node = JSON.parse(json).document;
     const result: string = renderer.render(node);
 
-    expect(result).toEqual("1. One\n  - Nested unordered\n\n2. Two\n  1. Nested ordered\n\n\n");
+    expect(result).toEqual(
+      "1. One\n  - Nested unordered\n\n2. Two\n  1. Nested ordered\n\n\n"
+    );
   });
 
   it("renders images", async () => {
-    const files = { "VlKCZMuShVzkE0pdnffR": "my-image.png" };
-    const renderer = new MarkdownRenderer(files, defaultSpaceContentTestInitializer);
+    const files = { VlKCZMuShVzkE0pdnffR: "my-image.png" };
+    const renderer = new MarkdownRenderer(
+      files,
+      defaultSpaceContentTestInitializer
+    );
     const json = await fs.readFile("fixtures/images.json", "utf8");
     const node = JSON.parse(json).document;
     const result: string = renderer.render(node);
@@ -60,8 +88,11 @@ describe("render", () => {
   });
 
   it("renders files", async () => {
-    const files = { "bYxy1vsBYjP2bXkJKFCb": "my-file.txt" };
-    const renderer = new MarkdownRenderer(files, defaultSpaceContentTestInitializer);
+    const files = { bYxy1vsBYjP2bXkJKFCb: "my-file.txt" };
+    const renderer = new MarkdownRenderer(
+      files,
+      defaultSpaceContentTestInitializer
+    );
     const json = await fs.readFile("fixtures/files.json", "utf8");
     const node = JSON.parse(json).document;
     const result: string = renderer.render(node);
@@ -74,7 +105,10 @@ describe("renderBlock()", () => {
   let renderer: MarkdownRenderer;
 
   beforeEach(() => {
-    renderer = new MarkdownRenderer(FilesInitializer, defaultSpaceContentTestInitializer);
+    renderer = new MarkdownRenderer(
+      FilesInitializer,
+      defaultSpaceContentTestInitializer
+    );
   });
 
   it("renders a heading", () => {
@@ -205,7 +239,7 @@ describe("renderBlock()", () => {
       object: "block",
       type: "hint",
       data: {
-        style: "info"
+        style: "info",
       },
       nodes: [
         {
@@ -215,20 +249,36 @@ describe("renderBlock()", () => {
           nodes: [
             {
               object: "text",
-              leaves: [{ object: "leaf", text: "An important hint callout block for user information.", marks: [], selections: [] }],
+              leaves: [
+                {
+                  object: "leaf",
+                  text: "An important hint callout block for user information.",
+                  marks: [],
+                  selections: [],
+                },
+              ],
             },
             {
               object: "text",
-              leaves: [{ object: "leaf", text: " Continued text.\nWith a newline.", marks: [], selections: [] }],
-            }
-          ]
+              leaves: [
+                {
+                  object: "leaf",
+                  text: " Continued text.\nWith a newline.",
+                  marks: [],
+                  selections: [],
+                },
+              ],
+            },
+          ],
         },
       ],
     };
 
     // it renders with 2 extra newlines which end up harmless, not worth diggin for now. Hack in place in renderBlock()
     // - Culprit is at the `(node.type == "paragraph") {` section adding extra \n's.
-    expect(renderer.renderBlock(node, 0)).toEqual("> An important hint callout block for user information. Continued text.\n> With a newline.\n\n");
+    expect(renderer.renderBlock(node, 0)).toEqual(
+      "> An important hint callout block for user information. Continued text.\n> With a newline.\n\n"
+    );
   });
 
   it("renders a code block", () => {
@@ -244,8 +294,8 @@ describe("renderBlock()", () => {
             {
               object: "text",
               leaves: [{ object: "leaf", text: "// line one", marks: [] }],
-            }
-          ]
+            },
+          ],
         },
         {
           object: "block",
@@ -254,13 +304,15 @@ describe("renderBlock()", () => {
             {
               object: "text",
               leaves: [{ object: "leaf", text: "// line two", marks: [] }],
-            }
-          ]
+            },
+          ],
         },
       ],
     };
 
-    expect(renderer.renderBlock(node, 0)).toEqual("```javascript\n// line one\n// line two\n```\n\n");
+    expect(renderer.renderBlock(node, 0)).toEqual(
+      "```javascript\n// line one\n// line two\n```\n\n"
+    );
   });
 
   it("renders a paragraph", () => {
@@ -289,7 +341,10 @@ describe("renderBlock()", () => {
 describe("renderInline()", () => {
   it("throws an error for unknown inline types", () => {
     const node: InlineNode = { object: "inline", type: "other-inline" };
-    const renderer = new MarkdownRenderer(FilesInitializer, defaultSpaceContentTestInitializer);
+    const renderer = new MarkdownRenderer(
+      FilesInitializer,
+      defaultSpaceContentTestInitializer
+    );
     expect(() => renderer.renderInline(node, 0)).toThrowError(
       "Unknown inline type: other-inline"
     );
@@ -304,7 +359,10 @@ describe("renderInline()", () => {
         { marks: [], object: "leaf", selections: [], text: "link text" },
       ],
     };
-    const renderer = new MarkdownRenderer(FilesInitializer, defaultSpaceContentTestInitializer);
+    const renderer = new MarkdownRenderer(
+      FilesInitializer,
+      defaultSpaceContentTestInitializer
+    );
     expect(renderer.renderInline(node, 0)).toEqual(
       "[link text](https://example.com)"
     );
@@ -312,67 +370,64 @@ describe("renderInline()", () => {
 
   it("renders Gitbook page links", () => {
     const node: gitbookLinkNode = {
-      "object": "inline",
-      "type": "link",
-      "isVoid": false,
-      "data": {
-          "ref": {
-              "kind": "page",
-              "page": "-M9UwQjn8e1kKADwPrrF"
-          }
+      object: "inline",
+      type: "link",
+      isVoid: false,
+      data: {
+        ref: {
+          kind: "page",
+          page: "-M9UwQjn8e1kKADwPrrF",
+        },
       },
-      "nodes": [
-          {
-              "object": "text",
-              "leaves": [
-                  {
-                      "object": "leaf",
-                      "text": "installing",
-                      "marks": [
-                          {
-                              "object": "mark",
-                              "type": "bold",
-                              "data": {}
-                          }
-                      ],
-                      "selections": []
-                  }
-              ]
-          }
-      ]
-  };
-
-  const spaceContent: SpaceContent = {
-    object: "revision",
-    id: "qCxFzUy2hI6unJ3GmG4Y",
-    parents: [
-        "6GqIbuAopAEOTYSG9sQZ",
-        "no294apqgYMSpghDgOHp"
-    ],
-    files: [],
-    pages: [
+      nodes: [
         {
-            "id": "-M9UwQjmVoE_PKEmahWz",
-            "title": "Getting started",
-            "kind": "group",
-            "type": "group",
-            "path": "getting-started",
-            "slug": "getting-started",
-            "pages": [
+          object: "text",
+          leaves: [
+            {
+              object: "leaf",
+              text: "installing",
+              marks: [
                 {
-                    "id": "-M9UwQjn8e1kKADwPrrF",
-                    "title": "Install Title",
-                    "kind": "sheet",
-                    "type": "document",
-                    "description": "",
-                    "path": "getting-started/install",
-                    "slug": "install",
-                    "pages": []
+                  object: "mark",
+                  type: "bold",
+                  data: {},
                 },
-              ]
-            }
-          ]
-        }
+              ],
+              selections: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const spaceContent: SpaceContent = {
+      object: "revision",
+      id: "qCxFzUy2hI6unJ3GmG4Y",
+      parents: ["6GqIbuAopAEOTYSG9sQZ", "no294apqgYMSpghDgOHp"],
+      files: [],
+      pages: [
+        {
+          id: "-M9UwQjmVoE_PKEmahWz",
+          title: "Getting started",
+          kind: "group",
+          type: "group",
+          path: "getting-started",
+          slug: "getting-started",
+          pages: [
+            {
+              id: "-M9UwQjn8e1kKADwPrrF",
+              title: "Install Title",
+              kind: "sheet",
+              type: "document",
+              description: "",
+              path: "getting-started/install",
+              slug: "install",
+              pages: [],
+            },
+          ],
+        },
+      ],
+    };
 
     const renderer = new MarkdownRenderer(FilesInitializer, spaceContent);
     expect(renderer.renderInline(node, 0)).toEqual(
@@ -384,12 +439,19 @@ describe("renderInline()", () => {
     const node: ImageLinkNode = {
       object: "inline",
       type: "inline-image",
-      data: { caption: "my image", ref: { url: "https://example.com" }, size: "line" },
+      data: {
+        caption: "my image",
+        ref: { url: "https://example.com" },
+        size: "line",
+      },
       leaves: [
         { marks: [], object: "leaf", selections: [], text: "link text" },
       ],
     };
-    const renderer = new MarkdownRenderer(FilesInitializer, defaultSpaceContentTestInitializer);
+    const renderer = new MarkdownRenderer(
+      FilesInitializer,
+      defaultSpaceContentTestInitializer
+    );
     expect(renderer.renderInline(node, 0)).toEqual(
       "![my image](https://example.com)"
     );
@@ -400,107 +462,116 @@ describe("renderInline()", () => {
       object: "inline",
       type: "inline-image",
       data: {
-        "ref": {
-            "kind": "file",
-            "file": "-M9ar8a0oxijwIvaQYA4"
+        ref: {
+          kind: "file",
+          file: "-M9ar8a0oxijwIvaQYA4",
         },
-        "size": "original"
-    },
+        size: "original",
+      },
       nodes: [
         {
-            "object": "text",
-            "leaves": [
-                {
-                    "object": "leaf",
-                    "text": "",
-                    "marks": [],
-                    "selections": []
-                }
-            ]
-        }
-    ]
+          object: "text",
+          leaves: [
+            {
+              object: "leaf",
+              text: "",
+              marks: [],
+              selections: [],
+            },
+          ],
+        },
+      ],
     };
-    const renderer = new MarkdownRenderer(FilesInitializer, defaultSpaceContentTestInitializer);
+    const renderer = new MarkdownRenderer(
+      FilesInitializer,
+      defaultSpaceContentTestInitializer
+    );
     expect(renderer.renderInline(node, 0)).toEqual(
       "![unknown-image-file.-M9ar8a0oxijwIvaQYA4]()"
     );
   });
 
   it("renders inline file images with info in Space", () => {
-    const spaceContent: SpaceContent = JSON.parse(JSON.stringify(defaultSpaceContentTestInitializer))
+    const spaceContent: SpaceContent = JSON.parse(
+      JSON.stringify(defaultSpaceContentTestInitializer)
+    );
     spaceContent.files = [
       {
-        "id": "-MC0GpDJ0v0g6fZ7qshj",
-        "name": "image.png",
-        "downloadURL": "https://files.gitbook.com/v0/b/gitbook-legacy-files/o/assets%2F-M8N-2NuR5V0ryoqtTWk%2F-MC0GoHeyr3P9glwOxk7%2F-MC0GpDJ0v0g6fZ7qshj%2Fimage.png?alt=media&token=5246ece1-816a-4432-b066-0f6709b06b4f",
-        "contentType": "image/png"
-    },
-    ]
+        id: "-MC0GpDJ0v0g6fZ7qshj",
+        name: "image.png",
+        downloadURL:
+          "https://files.gitbook.com/v0/b/gitbook-legacy-files/o/assets%2F-M8N-2NuR5V0ryoqtTWk%2F-MC0GoHeyr3P9glwOxk7%2F-MC0GpDJ0v0g6fZ7qshj%2Fimage.png?alt=media&token=5246ece1-816a-4432-b066-0f6709b06b4f",
+        contentType: "image/png",
+      },
+    ];
     const node: ImageFileNode = {
       object: "inline",
       type: "inline-image",
       data: {
-        "ref": {
-            "kind": "file",
-            "file": "-MC0GpDJ0v0g6fZ7qshj"
+        ref: {
+          kind: "file",
+          file: "-MC0GpDJ0v0g6fZ7qshj",
         },
-        "size": "original"
-    },
+        size: "original",
+      },
       nodes: [
         {
-            "object": "text",
-            "leaves": [
-                {
-                    "object": "leaf",
-                    "text": "",
-                    "marks": [],
-                    "selections": []
-                }
-            ]
-        }
-    ]
+          object: "text",
+          leaves: [
+            {
+              object: "leaf",
+              text: "",
+              marks: [],
+              selections: [],
+            },
+          ],
+        },
+      ],
     };
     const renderer = new MarkdownRenderer(FilesInitializer, spaceContent);
     expect(renderer.renderInline(node, 0)).toEqual(
-      "![download: https://files.gitbook.com/v0/b/gitbook-legacy-files/o/assets%2F-M8N-2NuR5V0ryoqtTWk%2F-MC0GoHeyr3P9glwOxk7%2F-MC0GpDJ0v0g6fZ7qshj%2Fimage.png?alt=media&token=5246ece1-816a-4432-b066-0f6709b06b4f](image.png \"-MC0GpDJ0v0g6fZ7qshj\")"
+      '![download: https://files.gitbook.com/v0/b/gitbook-legacy-files/o/assets%2F-M8N-2NuR5V0ryoqtTWk%2F-MC0GoHeyr3P9glwOxk7%2F-MC0GpDJ0v0g6fZ7qshj%2Fimage.png?alt=media&token=5246ece1-816a-4432-b066-0f6709b06b4f](image.png "-MC0GpDJ0v0g6fZ7qshj")'
     );
   });
 
   it("renders emojis", () => {
     const node: EmojiNode = {
-      "object": "inline",
-      "type": "emoji",
-      "isVoid": true,
-      "data": {
-          "code": "1f510"
+      object: "inline",
+      type: "emoji",
+      isVoid: true,
+      data: {
+        code: "1f510",
       },
-      "nodes": [
-          {
-              "object": "text",
-              "leaves": [
-                  {
-                      "object": "leaf",
-                      "text": "",
-                      "marks": [],
-                      "selections": []
-                  }
-              ]
-          }
-      ]
-  }
-    const renderer = new MarkdownRenderer(FilesInitializer, defaultSpaceContentTestInitializer);
-    expect(renderer.renderInline(node, 0)).toEqual(
-      "🔐 "
+      nodes: [
+        {
+          object: "text",
+          leaves: [
+            {
+              object: "leaf",
+              text: "",
+              marks: [],
+              selections: [],
+            },
+          ],
+        },
+      ],
+    };
+    const renderer = new MarkdownRenderer(
+      FilesInitializer,
+      defaultSpaceContentTestInitializer
     );
+    expect(renderer.renderInline(node, 0)).toEqual("🔐 ");
   });
-
 });
 
 describe("renderLeaf()", () => {
   let renderer: MarkdownRenderer;
 
   beforeEach(() => {
-    renderer = new MarkdownRenderer(FilesInitializer, defaultSpaceContentTestInitializer);
+    renderer = new MarkdownRenderer(
+      FilesInitializer,
+      defaultSpaceContentTestInitializer
+    );
   });
 
   it("renders plain text", () => {
@@ -509,7 +580,11 @@ describe("renderLeaf()", () => {
   });
 
   it("renders bold text", () => {
-    const node: LeafNode = { object: "leaf", text: "my text", marks: [{ object: "mark", type: "bold" }] };
+    const node: LeafNode = {
+      object: "leaf",
+      text: "my text",
+      marks: [{ object: "mark", type: "bold" }],
+    };
     expect(renderer.renderLeaf(node, 0)).toEqual("**my text**");
   });
 
@@ -535,7 +610,11 @@ describe("renderLeaf()", () => {
   });
 
   it("renders code", () => {
-    const node: LeafNode = { object: "leaf", text: "my text", marks: [{ object: "mark", type: "code" }] };
+    const node: LeafNode = {
+      object: "leaf",
+      text: "my text",
+      marks: [{ object: "mark", type: "code" }],
+    };
     expect(renderer.renderLeaf(node, 0)).toEqual("`my text`");
   });
 });

--- a/src/MarkdownRenderer.test.ts
+++ b/src/MarkdownRenderer.test.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "fs";
 import MarkdownRenderer from "./MarkdownRenderer";
 import type {
   BlockNode,
+  ImageBlockNode,
   InlineNode,
   LinkNode,
   gitbookLinkNode,
@@ -221,6 +222,37 @@ describe("renderBlock()", () => {
     );
   });
 
+  it("renders an image block with file metadata from Space", () => {
+    const localSpaceContent: SpaceContent = JSON.parse(
+      JSON.stringify(defaultSpaceContentTestInitializer)
+    );
+    localSpaceContent.files = [
+      {
+        id: "-MC0GpDJ0v0g6fZ7qshj",
+        name: "image.png",
+        downloadURL:
+          "https://files.gitbook.com/v0/b/gitbook-legacy-files/o/assets%2F-M8N-2NuR5V0ryoqtTWk%2F-MC0GoHeyr3P9glwOxk7%2F-MC0GpDJ0v0g6fZ7qshj%2Fimage.png?alt=media&token=5246ece1-816a-4432-b066-0f6709b06b4f",
+        contentType: "image/png",
+      },
+    ];
+    const localFilesLookup = {
+      "-MC0GpDJ0v0g6fZ7qshj": "image.png",
+    };
+    const node: ImageBlockNode = {
+      object: "block",
+      type: "image",
+      isVoid: true,
+      data: {
+        ref: {
+          kind: "file",
+          file: "-MC0GpDJ0v0g6fZ7qshj",
+        },
+      },
+    };
+    renderer = new MarkdownRenderer(localFilesLookup, localSpaceContent);
+    expect(renderer.renderBlock(node, 0)).toEqual("![](files/image.png)\n\n");
+  });
+
   it("renders a block quote", () => {
     const node: BlockNode = {
       object: "block",
@@ -406,7 +438,7 @@ describe("renderInline()", () => {
       ],
     };
 
-    const spaceContent: SpaceContent = {
+    const localSpaceContent: SpaceContent = {
       object: "revision",
       id: "qCxFzUy2hI6unJ3GmG4Y",
       parents: ["6GqIbuAopAEOTYSG9sQZ", "no294apqgYMSpghDgOHp"],
@@ -435,7 +467,7 @@ describe("renderInline()", () => {
       ],
     };
 
-    const renderer = new MarkdownRenderer(FilesInitializer, spaceContent);
+    const renderer = new MarkdownRenderer(FilesInitializer, localSpaceContent);
     expect(renderer.renderInline(node, 0)).toEqual(
       `[**installing**](/getting-started/install "Install Title")`
     );
@@ -510,10 +542,10 @@ describe("renderInline()", () => {
   });
 
   it("renders inline file images with info in Space", () => {
-    const spaceContent: SpaceContent = JSON.parse(
+    const localSpaceContent: SpaceContent = JSON.parse(
       JSON.stringify(defaultSpaceContentTestInitializer)
     );
-    spaceContent.files = [
+    localSpaceContent.files = [
       {
         id: "-MC0GpDJ0v0g6fZ7qshj",
         name: "image.png",
@@ -546,7 +578,7 @@ describe("renderInline()", () => {
         },
       ],
     };
-    const renderer = new MarkdownRenderer(FilesInitializer, spaceContent);
+    const renderer = new MarkdownRenderer(FilesInitializer, localSpaceContent);
     expect(renderer.renderInline(node, 0)).toEqual(
       '![download: https://files.gitbook.com/v0/b/gitbook-legacy-files/o/assets%2F-M8N-2NuR5V0ryoqtTWk%2F-MC0GoHeyr3P9glwOxk7%2F-MC0GpDJ0v0g6fZ7qshj%2Fimage.png?alt=media&token=5246ece1-816a-4432-b066-0f6709b06b4f](image.png "-MC0GpDJ0v0g6fZ7qshj")'
     );

--- a/src/MarkdownRenderer.ts
+++ b/src/MarkdownRenderer.ts
@@ -9,38 +9,38 @@ type BlockNode = Node & {
   object: "block";
   type: string;
   data?: {
-    syntax?: string,
-    style?: string
+    syntax?: string;
+    style?: string;
   };
 };
 
 type ImageBlockNode = BlockNode & {
-  type: "image",
+  type: "image";
   data: {
     ref: {
-      file: string,
-    },
+      file: string;
+    };
   };
 };
 
 type FileBlockNode = BlockNode & {
-  type: "file",
+  type: "file";
   data: {
     ref: {
-      file: string,
-    },
+      file: string;
+    };
   };
 };
 
 type InlineNode = Node & {
   object: "inline";
   type: string;
-  isVoid?: boolean,
+  isVoid?: boolean;
   data?: {
     ref?: {
-      kind?: string
-    }
-  }
+      kind?: string;
+    };
+  };
 };
 
 type LinkNode = InlineNode & {
@@ -50,7 +50,7 @@ type LinkNode = InlineNode & {
 
 type gitbookLinkNode = InlineNode & {
   type: "link";
-  data: { ref: { kind: "page", page: string } };
+  data: { ref: { kind: "page"; page: string } };
 };
 
 // two types: link image, or file in GitBook.
@@ -58,11 +58,11 @@ type gitbookLinkNode = InlineNode & {
 type ImageLinkNode = InlineNode & {
   type: "inline-image";
   data: {
-    caption: string,
+    caption: string;
     ref: {
-      url: string
-    },
-    size: string,
+      url: string;
+    };
+    size: string;
   };
 };
 
@@ -70,10 +70,10 @@ type ImageFileNode = InlineNode & {
   type: "inline-image";
   data: {
     ref: {
-      kind: string,
-      file: string
-    },
-    size: string,
+      kind: string;
+      file: string;
+    };
+    size: string;
   };
 };
 
@@ -81,13 +81,13 @@ type EmojiNode = InlineNode & {
   type: "emoji";
   data: {
     code: string;
-  }
-}
+  };
+};
 
 type Mark = {
   object: "mark";
   type: "bold" | "italic" | "code";
-  data?: {}
+  data?: {};
 };
 
 type LeafNode = Node & {
@@ -102,39 +102,39 @@ type Files = {
 };
 
 type SpaceContentPage = {
-  id: string,
-  title: string,
+  id: string;
+  title: string;
   kind: "sheet" | "group" | "link";
   type: "group" | "document" | "link";
-  description?: string,
-  path?: string,
-  slug?: string,
-  pages?: SpaceContentPage[]
-  href?: string
-}
+  description?: string;
+  path?: string;
+  slug?: string;
+  pages?: SpaceContentPage[];
+  href?: string;
+};
 
 // TODO: this is likely a duplicate of existing File type
 type SpaceContentFile = {
-  id: string,
-  name: string,
-  downloadURL: string,
-  contentType: string
-}
+  id: string;
+  name: string;
+  downloadURL: string;
+  contentType: string;
+};
 
 type SpaceContent = {
-  object: string,
-  id: string,
-  parents: string[]
-  pages: SpaceContentPage[],
-  files: SpaceContentFile[]
-}
+  object: string;
+  id: string;
+  parents: string[];
+  pages: SpaceContentPage[];
+  files: SpaceContentFile[];
+};
 
 function isLinkNode(node: InlineNode): node is LinkNode {
   return node.type === "link";
 }
 
 function isGitbookLinkNode(node: InlineNode): node is gitbookLinkNode {
-  return node.type === "link" && (node.data?.ref?.kind == "page");
+  return node.type === "link" && node.data?.ref?.kind == "page";
 }
 
 function isImageLinkNode(node: InlineNode): node is ImageLinkNode {
@@ -142,7 +142,7 @@ function isImageLinkNode(node: InlineNode): node is ImageLinkNode {
 }
 
 function isImageFileNode(node: InlineNode): node is ImageFileNode {
-  return node.type === "inline-image" && (node.data?.ref?.kind == "file");
+  return node.type === "inline-image" && node.data?.ref?.kind == "file";
 }
 
 function isEmojiNode(node: InlineNode): node is EmojiNode {
@@ -163,7 +163,7 @@ class MarkdownRenderer {
 
   constructor(files: Files = {}, spaceContent: SpaceContent) {
     this.files = files;
-    this.spaceContent = spaceContent
+    this.spaceContent = spaceContent;
     this.listCount = [];
     this.listType = [];
   }
@@ -219,11 +219,9 @@ class MarkdownRenderer {
       const headingLevel = parseInt(node.type.split("-").pop() || "2");
       const headingMark = "#".repeat(headingLevel);
       block = `${headingMark} ${getChildren()}\n\n`;
-
     } else if (node.type == "paragraph") {
       block = getChildren() + "\n";
       if (this.listCount.length == 0) block += "\n";
-
     } else if (node.type == "list-unordered" || node.type == "list-ordered") {
       this.listType.push(node.type);
       this.listCount.push(0);
@@ -233,7 +231,6 @@ class MarkdownRenderer {
 
       this.listType.pop();
       this.listCount.pop();
-
     } else if (node.type == "list-item") {
       const count = this.listCount[this.listCount.length - 1]++;
       block += " ".repeat((this.listCount.length - 1) * 2);
@@ -245,44 +242,39 @@ class MarkdownRenderer {
       }
 
       block += getChildren();
-
     } else if (isImageBlockNode(node)) {
       const fileId = node.data.ref.file;
       const filename = this.files[fileId];
       block = `![${getChildren().trim()}](files/${filename})\n\n`;
-
     } else if (isFileBlockNode(node)) {
       const fileId = node.data.ref.file;
       const filename = this.files[fileId];
       block = `[${getChildren().trim()}](files/${filename})\n\n`;
-
     } else if (node.type == "code") {
       block += "```";
       if (node.data) block += node.data.syntax;
       block += "\n";
       block += getChildren();
       block += "```\n\n";
-
     } else if (node.type == "code-line") {
       block += getChildren() + "\n";
-
     } else if (node.type == "blockquote") {
       block = getChildren()
         .split("\n")
         .map((line) => `> ${line}\n`)
         .join("");
     } else if (node.type == "hint") {
-        let children = getChildren()
-        // hack to remove extra newlines on hint blocks
-        if (children.slice(children.length-2, children.length) === "\n\n") {
-          children = children.slice(0, children.length-2)
-        }
-        block = children
-          .split("\n")
-          .map((line) => `> ${line}\n`)
-          .join("");
-        // add the newline back at the end, so that it pushes the next markdown block away.
-        block += "\n"
+      let children = getChildren();
+      // hack to remove extra newlines on hint blocks
+      if (children.slice(children.length - 2, children.length) === "\n\n") {
+        children = children.slice(0, children.length - 2);
+      }
+      block = children
+        .split("\n")
+        .map((line) => `> ${line}\n`)
+        .join("");
+      // add the newline back at the end, so that it pushes the next markdown block away.
+      block += "\n";
     } else {
       block = getChildren();
     }
@@ -297,15 +289,18 @@ class MarkdownRenderer {
   renderInline(node: InlineNode, depth: number) {
     if (isLinkNode(node)) {
       const text = this.renderChildren(node, depth);
-      let url = '';
-      let linkTitle = '';
+      let url = "";
+      let linkTitle = "";
       if (isGitbookLinkNode(node)) {
         const pageRef = node.data.ref.page;
         // this ID can be tied back to a page slug and more using the `content.json` file
         url = pageRef;
-        const pageInfo = this.findPageInfoFromGitbookPageRef(this.spaceContent.pages, pageRef)
+        const pageInfo = this.findPageInfoFromGitbookPageRef(
+          this.spaceContent.pages,
+          pageRef
+        );
         if (pageInfo) {
-          url = `/${pageInfo?.path}`
+          url = `/${pageInfo?.path}`;
           linkTitle = ` "${pageInfo.title}"`;
         }
       } else {
@@ -316,18 +311,21 @@ class MarkdownRenderer {
     } else if (isImageFileNode(node)) {
       const imageRef = node.data.ref.file;
       // TODO: go find the image file data!
-      const fileInfo = this.findFileInfoFromGitbookFileRef(this.spaceContent.files, imageRef)
+      const fileInfo = this.findFileInfoFromGitbookFileRef(
+        this.spaceContent.files,
+        imageRef
+      );
       if (fileInfo) {
         return `![download: ${fileInfo.downloadURL}](${fileInfo.name} "${fileInfo.id}")`;
       }
-      return `![unknown-image-file.${imageRef}]()`
+      return `![unknown-image-file.${imageRef}]()`;
     } else if (isImageLinkNode(node)) {
       const text = node.data.caption;
       const url = node.data.ref.url;
       return `![${text}](${url})`;
     } else if (isEmojiNode(node)) {
       const unicode_hex_code_point = node.data.code;
-      const hex_val = Number(`0x${unicode_hex_code_point}`)
+      const hex_val = Number(`0x${unicode_hex_code_point}`);
       return `${String.fromCodePoint(hex_val)} `;
     } else {
       throw `Unknown inline type: ${node.type}`;
@@ -377,14 +375,17 @@ class MarkdownRenderer {
       .join("\n");
   }
 
-  findPageInfoFromGitbookPageRef(searchPages: SpaceContentPage[], gitbookPageRef: string): SpaceContentPage | null {
+  findPageInfoFromGitbookPageRef(
+    searchPages: SpaceContentPage[],
+    gitbookPageRef: string
+  ): SpaceContentPage | null {
     for (const p of searchPages) {
       if (p.id === gitbookPageRef) {
         return p;
       } else if (p.pages) {
         // didn't find at top level, now do recursive pages
         let pageInfo: SpaceContentPage | null = null;
-        pageInfo = this.findPageInfoFromGitbookPageRef(p.pages, gitbookPageRef)
+        pageInfo = this.findPageInfoFromGitbookPageRef(p.pages, gitbookPageRef);
         if (pageInfo) {
           return pageInfo;
         }
@@ -393,7 +394,10 @@ class MarkdownRenderer {
     return null;
   }
 
-  findFileInfoFromGitbookFileRef(files: SpaceContentFile[], fileRef: string): SpaceContentFile | null {
+  findFileInfoFromGitbookFileRef(
+    files: SpaceContentFile[],
+    fileRef: string
+  ): SpaceContentFile | null {
     for (const f of files) {
       if (f.id === fileRef) {
         return f;
@@ -402,5 +406,19 @@ class MarkdownRenderer {
     return null;
   }
 }
-export type { Node, BlockNode, InlineNode, LinkNode, gitbookLinkNode, ImageLinkNode as ImageLinkNode, ImageFileNode, EmojiNode, LeafNode, Files, SpaceContent, SpaceContentFile, SpaceContentPage };
+export type {
+  Node,
+  BlockNode,
+  InlineNode,
+  LinkNode,
+  gitbookLinkNode,
+  ImageLinkNode as ImageLinkNode,
+  ImageFileNode,
+  EmojiNode,
+  LeafNode,
+  Files,
+  SpaceContent,
+  SpaceContentFile,
+  SpaceContentPage,
+};
 export default MarkdownRenderer;

--- a/src/MarkdownRenderer.ts
+++ b/src/MarkdownRenderer.ts
@@ -252,7 +252,7 @@ class MarkdownRenderer {
       block = `[${getChildren().trim()}](files/${filename})\n\n`;
     } else if (node.type == "code") {
       block += "```";
-      if (node.data) block += node.data.syntax;
+      if (node.data) block += node.data?.syntax || '';
       block += "\n";
       block += getChildren();
       block += "```\n\n";

--- a/src/MarkdownRenderer.ts
+++ b/src/MarkdownRenderer.ts
@@ -50,7 +50,7 @@ type LinkNode = InlineNode & {
 
 type gitbookLinkNode = InlineNode & {
   type: "link";
-  data: { ref: { kind: "page"; page: string } };
+  data: { ref: { kind: "page" | "anchor"; page: string, anchor?: string } };
 };
 
 // two types: link image, or file in GitBook.
@@ -134,7 +134,7 @@ function isLinkNode(node: InlineNode): node is LinkNode {
 }
 
 function isGitbookLinkNode(node: InlineNode): node is gitbookLinkNode {
-  return node.type === "link" && node.data?.ref?.kind == "page";
+  return node.type === "link" && ["page", "anchor"].includes(node.data?.ref?.kind || '');
 }
 
 function isImageLinkNode(node: InlineNode): node is ImageLinkNode {
@@ -293,6 +293,7 @@ class MarkdownRenderer {
       let linkTitle = "";
       if (isGitbookLinkNode(node)) {
         const pageRef = node.data.ref.page;
+        const anchor = node.data.ref.anchor ? `#${node.data.ref.anchor}`: '';
         // this ID can be tied back to a page slug and more using the `content.json` file
         url = pageRef;
         const pageInfo = this.findPageInfoFromGitbookPageRef(
@@ -303,6 +304,8 @@ class MarkdownRenderer {
           url = `/${pageInfo?.path}`;
           linkTitle = ` "${pageInfo.title}"`;
         }
+        // still add the anchor, since it's useful even without full page info
+        url = `${url}${anchor}`
       } else {
         url = node.data.ref.url;
         linkTitle = "";

--- a/src/MarkdownRenderer.ts
+++ b/src/MarkdownRenderer.ts
@@ -16,8 +16,10 @@ type BlockNode = Node & {
 
 type ImageBlockNode = BlockNode & {
   type: "image";
+  isVoid: boolean;
   data: {
     ref: {
+      kind: "file";
       file: string;
     };
   };
@@ -248,6 +250,8 @@ class MarkdownRenderer {
     } else if (isImageBlockNode(node)) {
       const fileId = node.data.ref.file;
       const filename = this.files[fileId];
+      // const fileInfo = this.findFileInfoFromGitbookFileRef(this.spaceContent.files, fileId)
+      // const filename = fileInfo?.name;
       block = `![${getChildren().trim()}](files/${filename})\n\n`;
     } else if (isFileBlockNode(node)) {
       const fileId = node.data.ref.file;
@@ -328,15 +332,8 @@ class MarkdownRenderer {
       return `[${text}](${url}${linkTitle})`;
     } else if (isImageFileNode(node)) {
       const imageRef = node.data.ref.file;
-      // TODO: go find the image file data!
-      const fileInfo = this.findFileInfoFromGitbookFileRef(
-        this.spaceContent.files,
-        imageRef
-      );
-      if (fileInfo) {
-        return `![download: ${fileInfo.downloadURL}](${fileInfo.name} "${fileInfo.id}")`;
-      }
-      return `![unknown-image-file.${imageRef}]()`;
+      const output = this.renderImageFile(imageRef);
+      return output;
     } else if (isImageLinkNode(node)) {
       const text = node.data.caption;
       const url = node.data.ref.url;
@@ -412,6 +409,18 @@ class MarkdownRenderer {
     return null;
   }
 
+  renderImageFile(imageRef: string) {
+    // TODO: this ignores existing captions
+    const fileInfo = this.findFileInfoFromGitbookFileRef(
+      this.spaceContent.files,
+      imageRef
+    );
+    if (fileInfo) {
+      return `![download: ${fileInfo.downloadURL}](${fileInfo.name} "${fileInfo.id}")`;
+    }
+    return `![unknown-image-file.${imageRef}]()`;
+  }
+
   findFileInfoFromGitbookFileRef(
     files: SpaceContentFile[],
     fileRef: string
@@ -427,6 +436,7 @@ class MarkdownRenderer {
 export type {
   Node,
   BlockNode,
+  ImageBlockNode,
   InlineNode,
   LinkNode,
   gitbookLinkNode,

--- a/src/MarkdownRenderer.ts
+++ b/src/MarkdownRenderer.ts
@@ -9,7 +9,8 @@ type BlockNode = Node & {
   object: "block";
   type: string;
   data?: {
-    syntax: string,
+    syntax?: string,
+    style?: string
   };
 };
 
@@ -253,7 +254,18 @@ class MarkdownRenderer {
         .split("\n")
         .map((line) => `> ${line}\n`)
         .join("");
-
+    } else if (node.type == "hint") {
+        let children = getChildren()
+        // hack to remove extra newlines on hint blocks
+        if (children.slice(children.length-2, children.length) === "\n\n") {
+          children = children.slice(0, children.length-2)
+        }
+        block = children
+          .split("\n")
+          .map((line) => `> ${line}\n`)
+          .join("");
+        // add the newline back at the end, so that it pushes the next markdown block away.
+        block += "\n"
     } else {
       block = getChildren();
     }

--- a/src/convertToMarkdown.ts
+++ b/src/convertToMarkdown.ts
@@ -2,11 +2,16 @@ import { promises as fs } from "fs";
 import MarkdownRenderer from "./MarkdownRenderer.js";
 import type { Files, SpaceContent } from "./MarkdownRenderer.js";
 
-export default async (filename: string, files: Files = {}, spaceContent: SpaceContent) => {
+export default async (
+  filename: string,
+  files: Files = {},
+  spaceContent: SpaceContent
+) => {
   const renderer = new MarkdownRenderer(files, spaceContent);
   const file = await fs.readFile(filename, "utf8");
   const data = JSON.parse(file);
-  const output = data.kind == "sheet" ? renderer.render(data.document) : undefined;
+  const output =
+    data.kind == "sheet" ? renderer.render(data.document) : undefined;
 
   return output;
 };

--- a/src/convertToMarkdown.ts
+++ b/src/convertToMarkdown.ts
@@ -1,9 +1,9 @@
 import { promises as fs } from "fs";
 import MarkdownRenderer from "./MarkdownRenderer.js";
-import type { Files } from "./MarkdownRenderer.js";
+import type { Files, SpaceContent } from "./MarkdownRenderer.js";
 
-export default async (filename: string, files: Files = {}) => {
-  const renderer = new MarkdownRenderer(files);
+export default async (filename: string, files: Files = {}, spaceContent: SpaceContent) => {
+  const renderer = new MarkdownRenderer(files, spaceContent);
   const file = await fs.readFile(filename, "utf8");
   const data = JSON.parse(file);
   const output = data.kind == "sheet" ? renderer.render(data.document) : undefined;

--- a/src/get-content.ts
+++ b/src/get-content.ts
@@ -20,8 +20,14 @@ const getContent = async () => {
     await fs.mkdir(`data`);
   } catch (error) { }
 
+  let gitbookSpacesUrl = `https://api.gitbook.com/v1/orgs/${orgId}/spaces`;
+  if (orgId === "personal") {
+    // pulls spaces for the user who owns the API Token
+    gitbookSpacesUrl = "https://api.gitbook.com/v1/user/spaces";
+  }
+
   const spaces = await axios.get(
-    `https://api.gitbook.com/v1/orgs/${orgId}/spaces`,
+    gitbookSpacesUrl,
     config
   );
 

--- a/src/get-content.ts
+++ b/src/get-content.ts
@@ -18,7 +18,7 @@ const config = { headers: { Authorization: `Bearer ${apiToken}` } };
 const getContent = async () => {
   try {
     await fs.mkdir(`data`);
-  } catch (error) { }
+  } catch (error) {}
 
   let gitbookSpacesUrl = `https://api.gitbook.com/v1/orgs/${orgId}/spaces`;
   if (orgId === "personal") {
@@ -26,16 +26,13 @@ const getContent = async () => {
     gitbookSpacesUrl = "https://api.gitbook.com/v1/user/spaces";
   }
 
-  const spaces = await axios.get(
-    gitbookSpacesUrl,
-    config
-  );
+  const spaces = await axios.get(gitbookSpacesUrl, config);
 
   for (let space of spaces.data.items) {
     console.log(space.title);
     try {
       await fs.mkdir(`data/${space.title}`);
-    } catch (error) { }
+    } catch (error) {}
     const content = await axios.get(
       `https://api.gitbook.com/v1/spaces/${space.id}/content`,
       { ...config, responseType: "stream" }

--- a/src/get-files.ts
+++ b/src/get-files.ts
@@ -24,11 +24,11 @@ const getFiles = async (spaceName: string) => {
 
   try {
     await fs.mkdir(`data/${spaceName}/files`);
-  } catch (error) { }
+  } catch (error) {}
 
   await Promise.all(
     content.files.map((file: { downloadURL: string }) => {
-      getFile(spaceName, file.downloadURL)
+      getFile(spaceName, file.downloadURL);
     })
   );
 };

--- a/src/get-pages.ts
+++ b/src/get-pages.ts
@@ -23,7 +23,9 @@ type Node = {
 const fetchPage = async (spaceId: string, spaceName: string, path: string) => {
   try {
     const page = await axios.get(
-      `https://api.gitbook.com/v1/spaces/${spaceId}/content/path/${encodeURIComponent(path)}`,
+      `https://api.gitbook.com/v1/spaces/${spaceId}/content/path/${encodeURIComponent(
+        path
+      )}`,
       { ...config, responseType: "stream" }
     );
     const f = await fs.open(`data/${spaceName}/${path}.json`, "w");
@@ -33,13 +35,18 @@ const fetchPage = async (spaceId: string, spaceName: string, path: string) => {
   }
 };
 
-const fetchPath = async (spaceName: string, spaceId: string, path: string, node: Node) => {
+const fetchPath = async (
+  spaceName: string,
+  spaceId: string,
+  path: string,
+  node: Node
+) => {
   const absNodePath = node.path ? `${node.path}` : path;
 
   if (node.path !== undefined) {
     try {
       await fs.mkdir(`data/${spaceName}/${path}`);
-    } catch (error) { }
+    } catch (error) {}
     console.log(absNodePath);
 
     await fetchPage(spaceId, spaceName, absNodePath);

--- a/src/gitbook-to-md.ts
+++ b/src/gitbook-to-md.ts
@@ -1,7 +1,22 @@
+import { promises as fs } from "fs";
 import convertToMarkdown from "./convertToMarkdown.js";
+import type { SpaceContent } from "./MarkdownRenderer.js";
 
-const processFile: string = process.argv[2];
+const spaceName: string = process.argv[2];
+const processFile: string = process.argv[3];
 
-convertToMarkdown(processFile).then((markdown) => {
+if (process.argv.length < 3) {
+  console.error("Usage: npm run gitbook-to-md -- [Space Name] [page.json]");
+  process.exit(1);
+}
+
+const parsePage = async (spaceName: string, processFile: string) => {
+  const spaceContent: SpaceContent = JSON.parse(
+    await fs.readFile(`data/${spaceName}/content.json`, "utf8")
+  );
+  return convertToMarkdown(processFile, undefined, spaceContent);
+};
+
+parsePage(spaceName, processFile).then((markdown) => {
   console.log(markdown);
 });

--- a/src/parse-pages.ts
+++ b/src/parse-pages.ts
@@ -1,7 +1,12 @@
 import { promises as fs } from "fs";
 import convertToMarkdown from "./convertToMarkdown.js";
 import { extractFilename } from "./utils.js";
-import type { Files, SpaceContent, SpaceContentFile, SpaceContentPage } from "./MarkdownRenderer.js";
+import type {
+  Files,
+  SpaceContent,
+  SpaceContentFile,
+  SpaceContentPage,
+} from "./MarkdownRenderer.js";
 
 if (process.argv.length < 2) {
   console.error("Usage: npm run parse-pages -- [space name]");
@@ -23,7 +28,11 @@ const buildFilesLookup = (files: GitbookFile[]) => {
   }, {});
 };
 
-const readDir = async (path: string, fileURLs: Files, spaceContent: SpaceContent) => {
+const readDir = async (
+  path: string,
+  fileURLs: Files,
+  spaceContent: SpaceContent
+) => {
   const filenames = await fs.readdir(path);
 
   for (const file of filenames) {

--- a/src/parse-pages.ts
+++ b/src/parse-pages.ts
@@ -58,7 +58,6 @@ const parsePages = async (spaceName: string) => {
     await fs.readFile(`data/${spaceName}/content.json`, "utf8")
   );
   const fileURLs = buildFilesLookup(spaceContent.files);
-
   await readDir(`data/${spaceName}`, fileURLs, spaceContent);
 };
 

--- a/src/parse-pages.ts
+++ b/src/parse-pages.ts
@@ -13,7 +13,7 @@ if (process.argv.length < 2) {
   process.exit(1);
 }
 
-const spaceName: string = process.argv[2];
+const spaceNameArg: string = process.argv[2];
 
 type GitbookFile = {
   id: string;
@@ -53,6 +53,7 @@ const readDir = async (
 };
 
 const parsePages = async (spaceName: string) => {
+  console.log(`[*] Parsing started for ${spaceName}...`);
   const spaceContent: SpaceContent = JSON.parse(
     await fs.readFile(`data/${spaceName}/content.json`, "utf8")
   );
@@ -61,4 +62,4 @@ const parsePages = async (spaceName: string) => {
   await readDir(`data/${spaceName}`, fileURLs, spaceContent);
 };
 
-parsePages(spaceName).then(() => console.log("Done"));
+parsePages(spaceNameArg).then(() => console.log("Done"));


### PR DESCRIPTION
Dove in to just fix page links, ended up finding and touching up a variety of other things I ran into.

### Changes
- Now able to pull Spaces from a user's `personal`, not just an organization space
- GitBook page links were `undefined`, now are connected to the actual page metadata and look like `[Submit](/docs/requests/submit "Submit a Request")`
- Hint blocks were `undefined`, now are rendered as block quote with emoji (see README for example).
- inline images in some cases were `undefined`
- anchor links were showing as `undefined`
- Added unit tests for the new functionality

### QA

- [x] Unit tests pass
- [x] Files formatted with Prettier
- [x] type checks pass
- [x] No undefined showing when run on actual Spaces

### Areas for potential improvement

I was moving fast and didn't have the time to hit every area I might have liked to.

- I believe the `files` lookup dict could be combined with the `spaceContent` data that I added to the markdown renderer
